### PR TITLE
Fix error when rendering pluginConfig

### DIFF
--- a/templates/partials/init-tecart-cookie-banner.html.twig
+++ b/templates/partials/init-tecart-cookie-banner.html.twig
@@ -1,7 +1,7 @@
 {# Add listener to window load to initialize the cookie banner correct. #}
 window.addEventListener("load", function() {
 
-	var pluginConfig = {{ config.plugins["tecart-cookie-manager"]|json_encode }};
+    var pluginConfig = {{ config.plugins["tecart-cookie-manager"]|json_encode|raw }};
     var cookieBannerData = {{ cookieBannerData|json_encode|raw }};
     var cookieBannerScripts = {{ cookieBannerScripts["scripts"]|json_encode|raw }};
     var cookieBannerCategories = {{ cookieBannerCategories["categories"]|json_encode|raw }};


### PR DESCRIPTION
Without this change I get a javacript error `Uncaught SyntaxError: Unexpected token '&'` after rendering the template. That is because it gets rendered as `var pluginConfig = {&quot;enabled&quot;:true,&quot` which is obviously not correct.