### PR TITLE
Spanish translation added and improved other translations.

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -33,33 +33,33 @@ form:
             type: select
             size: small
             classes: fancy
-            label: Data Storage
+            label: PLUGIN_TECART_COOKIE_MANGER.DATA_STORAGE
             default: data
             options:
                 pages: pages/assets
                 data: user/data
         custom_settings_link:
             type: section
-            title: Custom Link to Settings
+            title: PLUGIN_TECART_COOKIE_MANGER.CUSTOM_SETTINGS.TITLE
             underline: true
             fields:
                 custom_settings_link_info:
                     type: display
-                    label: Info
+                    label: PLUGIN_TECART_COOKIE_MANGER.CUSTOM_SETTINGS.LINK_INFO.LABEL
                     markdown: true
-                    content: "Texts and colors, if a link to open the setting should be set anywhere in the theme, but the text is maintained in the admin panel. It is important to use the **tcb-settings-link** class, which opens the modal. Text and color can be called up in Twig via the plugin config variables. See readme for more info."
+                    content: PLUGIN_TECART_COOKIE_MANGER.CUSTOM_SETTINGS.LINK_INFO.CONTENT
                 custom_settings_link_text:
                     type: text
                     size: large
-                    default: Cookie Banner Einstellungen
-                    label: Link Text
+                    default: PLUGIN_TECART_COOKIE_MANGER.CUSTOM_SETTINGS.LINK_TEXT.DEFAULT
+                    label: PLUGIN_TECART_COOKIE_MANGER.CUSTOM_SETTINGS.LINK_TEXT.LABEL
                 custom_settings_link_color:
                     type: text
                     size: small
-                    label: Background color if button
+                    label: PLUGIN_TECART_COOKIE_MANGER.CUSTOM_SETTINGS.LINK_BACKGROUND_COLOR
                     default: '#7faf34'
                 custom_settings_link_text_color:
                     type: text
                     size: small
-                    label: Text color
+                    label: PLUGIN_TECART_COOKIE_MANGER.CUSTOM_SETTINGS.LINK_TEXT_COLOR
                     default: '#ffffff'

--- a/languages.yaml
+++ b/languages.yaml
@@ -2,11 +2,11 @@ en:
   PLUGIN_TECART_COOKIE_MANGER:
     COOKIE_MANAGER: "Cookie Manager"
     COOKIE_MANAGER_SUB: "by TecArt GmbH"
-    CATEGORIES: Kategorien
+    CATEGORIES: Categories
     BANNER: Banner
     SCRIPTS: Scripts
     SCRIPT_TITLE: Script title
-    BANNER_TEXT_DEFAULT: Sie helfen uns, die Nutzung unserer Websites besser zu verstehen, damit wir Ihnen maßgeschneiderte Inhalten anbieten können.
+    BANNER_TEXT_DEFAULT: They help us better understand how our websites are used so that we can offer you tailored content.
     TITLE_VALIDATE_MESSAGE: Please enter a title!
     CODE_VALIDATE_MESSAGE: Please enter script code!
     TEXT_VALIDATE_MESSAGE: Please enter a description!
@@ -40,3 +40,17 @@ fr:
     TEXT_VALIDATE_MESSAGE: Veuillez indiquer une description !
     SCRIPT_CATEGORY_VALIDATE_MESSAGE: Veuillez indiquer une catégorie !
     COOKIE_MANAGER_SCRIPT_ADVISE: Veuillez créer au moins une catégorie que vous pouvez affecter au script.
+es:
+  PLUGIN_TECART_COOKIE_MANGER:
+    COOKIE_MANAGER: "Gestor de Cookies"
+    COOKIE_MANAGER_SUB: "por TecArt GmbH"
+    CATEGORIES: Categorías
+    BANNER: Banner
+    SCRIPTS: Scripts
+    SCRIPT_TITLE: Título del Script
+    BANNER_TEXT_DEFAULT: Nos ayudan a comprender mejor cómo se utilizan nuestros sitios web para que podamos ofrecerle contenido personalizado.
+    TITLE_VALIDATE_MESSAGE: ¡Por favor, introduzca un título!
+    CODE_VALIDATE_MESSAGE: ¡Por favor, introduzca el código del script!
+    TEXT_VALIDATE_MESSAGE: ¡Por favor, introduzca una descripción!
+    SCRIPT_CAT_VALIDATE_MESSAGE: ¡Por favor, establezca una categoría!
+    COOKIE_MANAGER_SCRIPT_ADVISE: ¡Por favor, crea mínimo una categoría para asignar al script.

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,5 +1,16 @@
 en:
   PLUGIN_TECART_COOKIE_MANGER:
+    DATA_STORAGE: Data Storage
+    CUSTOM_SETTINGS:
+      TITLE: Custom Link to Settings
+      LINK_INFO:
+        LABEL: Info
+        CONTENT: "Texts and colors, if a link to open the setting should be set anywhere in the theme, but the text is maintained in the admin panel. It is important to use the **tcb-settings-link** class, which opens the modal. Text and color can be called up in Twig via the plugin config variables. See readme for more info."
+      LINK_TEXT:
+        LABEL: Link Text
+        DEFAULT: Cookie Banner Einstellungen
+      LINK_BACKGROUND_COLOR: Background color if button
+      LINK_TEXT_COLOR: Text color
     COOKIE_MANAGER: "Cookie Manager"
     COOKIE_MANAGER_SUB: "by TecArt GmbH"
     CATEGORIES: Categories
@@ -14,6 +25,17 @@ en:
     COOKIE_MANAGER_SCRIPT_ADVISE: Please create min. one category that you can assign to the script.
 de:
   PLUGIN_TECART_COOKIE_MANGER:
+    DATA_STORAGE: Data Storage
+    CUSTOM_SETTINGS:
+      TITLE: Custom Link to Settings
+      LINK_INFO:
+        LABEL: Info
+        CONTENT: "Texts and colors, if a link to open the setting should be set anywhere in the theme, but the text is maintained in the admin panel. It is important to use the **tcb-settings-link** class, which opens the modal. Text and color can be called up in Twig via the plugin config variables. See readme for more info."
+      LINK_TEXT:
+        LABEL: Link Text
+        DEFAULT: Cookie Banner Einstellungen
+      LINK_BACKGROUND_COLOR: Background color if button
+      LINK_TEXT_COLOR: Text color
     COOKIE_MANAGER: "Cookie Manager"
     COOKIE_MANAGER_SUB: "by TecArt GmbH"
     CATEGORIES: Kategorien
@@ -28,6 +50,17 @@ de:
     COOKIE_MANAGER_SCRIPT_ADVISE: Bitte legen Sie zuerst mindestens eine Kategorie an, die Sie dem Script zuordnen können.
 fr:
   PLUGIN_TECART_COOKIE_MANGER:
+    DATA_STORAGE: Data Storage
+    CUSTOM_SETTINGS:
+      TITLE: Custom Link to Settings
+      LINK_INFO:
+        LABEL: Info
+        CONTENT: "Texts and colors, if a link to open the setting should be set anywhere in the theme, but the text is maintained in the admin panel. It is important to use the **tcb-settings-link** class, which opens the modal. Text and color can be called up in Twig via the plugin config variables. See readme for more info."
+      LINK_TEXT:
+        LABEL: Link Text
+        DEFAULT: Cookie Banner Einstellungen
+      LINK_BACKGROUND_COLOR: Background color if button
+      LINK_TEXT_COLOR: Text color
     COOKIE_MANAGER: "Cookie Manager"
     COOKIE_MANAGER_SUB: "par TecArt GmbH"
     CATEGORIES: Catégories
@@ -42,7 +75,18 @@ fr:
     COOKIE_MANAGER_SCRIPT_ADVISE: Veuillez créer au moins une catégorie que vous pouvez affecter au script.
 es:
   PLUGIN_TECART_COOKIE_MANGER:
-    COOKIE_MANAGER: "Gestor de Cookies"
+    DATA_STORAGE: Data Storage
+    CUSTOM_SETTINGS:
+      TITLE: Custom Link to Settings
+      LINK_INFO:
+        LABEL: Info
+        CONTENT: "Texts and colors, if a link to open the setting should be set anywhere in the theme, but the text is maintained in the admin panel. It is important to use the **tcb-settings-link** class, which opens the modal. Text and color can be called up in Twig via the plugin config variables. See readme for more info."
+      LINK_TEXT:
+        LABEL: Link Text
+        DEFAULT: Cookie Banner Einstellungen
+      LINK_BACKGROUND_COLOR: Background color if button
+      LINK_TEXT_COLOR: Text color
+    COOKIE_MANAGER: "Administrador de Cookies"
     COOKIE_MANAGER_SUB: "por TecArt GmbH"
     CATEGORIES: Categorías
     BANNER: Banner

--- a/languages/es.yaml
+++ b/languages/es.yaml
@@ -1,5 +1,5 @@
 PLUGIN_TECART_COOKIE_MANAGER:
-  COOKIE_MANAGER: "Gestor de Cookies"
+  COOKIE_MANAGER: "Administrador de Cookies"
   COOKIE_MANAGER_SUB: "por TecArt GmbH"
   CATEGORIES: Categorías
   BANNER: Banner
@@ -28,7 +28,7 @@ PLUGIN_TECART_COOKIE_MANAGER:
   BUTTON_LAYOUT_1: transparente
   BUTTON_TEXT: Texto del botón
   BUTTON_ICON: Icono fontawesome del botón
-  BUTTON_ICON_LINK: usable icons - <a href="https://fontawesome.com/icons?d=gallery&s=solid&m=free" target="_blank" alt="FontAwesome Galary">FontAwesome</a>
+  BUTTON_ICON_LINK: Iconos utilizables - <a href="https://fontawesome.com/icons?d=gallery&s=solid&m=free" target="_blank" alt="FontAwesome Gallery">FontAwesome</a>
   BUTTON_SAVE: Botón Guardar
   BUTTON_ACTIVE: Botón Activo
   BUTTON_ACTIVATED: activo

--- a/languages/es.yaml
+++ b/languages/es.yaml
@@ -1,5 +1,5 @@
 PLUGIN_TECART_COOKIE_MANAGER:
-  COOKIE_MANAGER: "Administrador de Cookies"
+  COOKIE_MANAGER: "Gestor de Cookies"
   COOKIE_MANAGER_SUB: "por TecArt GmbH"
   CATEGORIES: Categorías
   BANNER: Banner
@@ -28,7 +28,7 @@ PLUGIN_TECART_COOKIE_MANAGER:
   BUTTON_LAYOUT_1: transparente
   BUTTON_TEXT: Texto del botón
   BUTTON_ICON: Icono fontawesome del botón
-  BUTTON_ICON_LINK: Iconos utilizables - <a href="https://fontawesome.com/icons?d=gallery&s=solid&m=free" target="_blank" alt="FontAwesome Gallery">FontAwesome</a>
+  BUTTON_ICON_LINK: usable icons - <a href="https://fontawesome.com/icons?d=gallery&s=solid&m=free" target="_blank" alt="FontAwesome Galary">FontAwesome</a>
   BUTTON_SAVE: Botón Guardar
   BUTTON_ACTIVE: Botón Activo
   BUTTON_ACTIVATED: activo

--- a/languages/es.yaml
+++ b/languages/es.yaml
@@ -1,0 +1,73 @@
+PLUGIN_TECART_COOKIE_MANAGER:
+  COOKIE_MANAGER: "Gestor de Cookies"
+  COOKIE_MANAGER_SUB: "por TecArt GmbH"
+  CATEGORIES: Categorías
+  BANNER: Banner
+  SCRIPTS: Scripts
+  BANNER_SECTION_CONTENT: Contenido del banner
+  BANNER_TEXT: Texto del banner
+  BANNER_TEXT_DEFAULT: Las cookies nos ayudan a comprender mejor el uso de nuestros sitios web para que podamos ofrecerle contenido personalizado.
+  BANNER_TITLE: Título del banner
+  BANNER_TITLE_HELP: Título del baner principal de cookies
+  BANNER_TITLE_DEFAULT: Las cookies son buenas para usted
+  BANNER_CAT_TITLE: Título del banner de categoría
+  BANNER_CAT_TITLE_HELP: Título del banner con la descripción general de la categoría
+  BANNER_CAT_TITLE_DEFAULT: Su administrador personal de banner de cookies
+  BANNER_SECTION_BUTTON_ACCEPT: Botón Aceptar
+  BUTTON_ACCEPT_TEXT_DEFAULT: Aceptar
+  BANNER_SECTION_BUTTON_SETTINGS: Botón configuración
+  BUTTON_SETTINGS_TEXT_DEFAULT: Configuración
+  SETTINGS_EMPTY: Texto si no hay categorías o scripts disponibles.
+  BANNER_SECTION_BUTTON_DENY: Botón Denegar
+  BANNER_SECTION_REVOKABLE: Banner revocable
+  BANNER_REVOKABLE_TEXT: Texto del banner revocable
+  BUTTON_REVOKABLE_COLOR: Bolor de fondo del botón
+  BUTTON_REVOKABLE_TEXT_COLOR: Color del texto del botón
+  BUTTON_LAYOUT: Diseño del botón
+  BUTTON_LAYOUT_2: estándar
+  BUTTON_LAYOUT_1: transparente
+  BUTTON_TEXT: Texto del botón
+  BUTTON_ICON: Icono fontawesome del botón
+  BUTTON_ICON_LINK: usable icons - <a href="https://fontawesome.com/icons?d=gallery&s=solid&m=free" target="_blank" alt="FontAwesome Galary">FontAwesome</a>
+  BUTTON_SAVE: Botón Guardar
+  BUTTON_ACTIVE: Botón Activo
+  BUTTON_ACTIVATED: activo
+  BUTTON_DEACTIVATED: inactivo
+  CATEGORY_TITLE: Título de la categoría
+  CATEGORY_TEXT:  Texto de la categoría
+  CATEGORY_ADD: Añadir categoría
+  CATEGORY_COOKIES: Habilitar todas las cookies
+  CATEGORY_COOKIES_ACTIVATED: Mostrar
+  CATEGORY_COOKIES_DEACTIVATED: Ocultar
+  CATEGORY_COOKIES_HELP: Ayuda
+  CATEGORY_COOKIES_HELPTEXT: Si está visible, se genera el alternador de categoría, se establece en "activado" y todos los scripts/cookies en esta categoría se activan inicialmente. Si no está visible, no se mostrará ningún alternador.
+  CATEGORY_SAVE_SETTINGS_BTN: Guardar configuración
+  SCRIPT_ADD: Nuevo script
+  SCRIPT_TITLE: Título del script
+  SCRIPT_TEXT: Texto del script
+  SCRIPT_CATEGORY: Categoría
+  SCRIPT_COOKIES_STANDARD: Por defecto (script incluido o no)
+  SCRIPT_COOKIES: Registrarse (mostrar casilla de verificación en el banner)
+  SCRIPT_COOKIES_STANDARD_ACTIVATED: activo
+  SCRIPT_COOKIES_STANDARD_DEACTIVATED: inactivo
+  SCRIPT_LOAD_ON_SCROLL_PERCENT: Cargar después de % de desplazamiento
+  SCRIPT_CODE: Código (las etiquetas de script se generaron automáticamente)
+  SCRIPT_CODE_ADD: Nuevo código
+  SCRIPT_CODE_POSITION: Posición
+  SCRIPT_CODE_BODY_TOP: Inicio del cuerpo de HTML
+  SCRIPT_CODE_BODY_BOTTOM: Final del cuerpo de HTML
+  SCRIPT_CODE_HEAD: Encabezado HTML
+  SCRIPT_CODE_TAG: Elemento de etiqueta HTML
+  SCRIPT_CODE_TAG_SCRIPT: script
+  SCRIPT_CODE_TAG_NOSCRIPT: noscript
+  SCRIPT_CODE_LOAD_WITH_TIMEOUT: Carga el script con retardo
+  SCRIPT_CODE_LOAD_WITH_TIMEOUT_TIME: Tiempo de espera en ms (3s = 3000ms)
+  SCRIPT_CODE_LOAD_ON_SCROLL: Cargar script al desplazarse
+  SCRIPT_CODE_LOAD_ON_PAGES: Cargar script en páginas
+  SCRIPT_CODE_LOAD_ON_PAGES_HELP: Incluir el script solo en páginas específicas.
+  YES: si
+  NO: no
+  TITLE_VALIDATE_MESSAGE: ¡Por favor, introduzca un título!
+  CODE_VALIDATE_MESSAGE: ¡Por favor, introduzca el código del script!
+  TEXT_VALIDATE_MESSAGE: ¡Por favor, introduzca una descripción!
+  SCRIPT_CATEGORY_VALIDATE_MESSAGE: ¡Por favor, establezca una categoría!


### PR DESCRIPTION
In blueprints.yaml the line:
`default: PLUGIN_TECART_COOKIE_MANGER.CUSTOM_SETTINGS.LINK_TEXT.DEFAULT` is not translated correctly because there may be some bug in the Grav core.